### PR TITLE
URL decode S3 key name and set ClientRequestToken and JobTag to eTag before invoking Textract

### DIFF
--- a/functions/textract-job-submit-async.py
+++ b/functions/textract-job-submit-async.py
@@ -2,7 +2,7 @@ import os
 import time
 import boto3
 from datetime import datetime
-
+from urllib.parse import unquote_plus
 
 def attachExternalBucketPolicy(externalBucketName):
     iam = boto3.client('iam')
@@ -387,7 +387,7 @@ def lambda_handler(event, context):
         record, = event["Records"]        
         print(record)
         bucket = record['s3']['bucket']['name']
-        document = record['s3']['object']['key']
+        document = unquote_plus(record['s3']['object']['key'])
     else:
         bucket = event['ExternalBucketName']
         document = event['ExternalDocumentPrefix']   


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/amazon-textract-enhancer/issues/2

*Description of changes:*

1. Used urllib to decode the value of the S3 Key received from the S3 event. The S3 event sends an encoded key name, e.g. spaces are replaced with plus (+); without decoding, this leads to the wrong object name being sent when invoking Textract. 

2. Although the S3 key name used when invoking Textract may contain spaces or plusses, Textract will throw an error if the `ClientRequestToken` or `JobTag` has a space or plus. Since current code bases these two parameter values on the S3 object's name, this will lead to errors if the object name contains spaces or plusses. So, I changed these two parameters to instead derive their value from the S3 object's `eTag` (which is its MD5 value). 

I tested with a file named "My Test.pdf" in S3. Prior to this PR, the Textract invokes failed and it now works. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
